### PR TITLE
Revert "change submit instrument validation"

### DIFF
--- a/packages/validation/package-lock.json
+++ b/packages/validation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@esss-swap/duo-validation",
-	"version": "1.1.43",
+	"version": "1.1.42",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esss-swap/duo-validation",
-  "version": "1.1.43",
+  "version": "1.1.42",
   "description": "Duo frontend and backend validation in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/validation/src/Instrument/index.ts
+++ b/packages/validation/src/Instrument/index.ts
@@ -56,7 +56,7 @@ export const setAvailabilityTimeOnInstrumentValidationSchema = Yup.object().shap
 );
 
 export const submitInstrumentValidationSchema = Yup.object().shape({
+  callId: Yup.number().required(),
   instrumentId: Yup.number().required(),
-  proposalIds: Yup.array(Yup.number()).required(),
   sepId: Yup.number().required(),
 });


### PR DESCRIPTION
Reverts UserOfficeProject/user-office-lib#21

I am reverting this because I will keep the old way of sending parameters and get the proposalIds on the backend. This way is much better.