### PR TITLE
Swap 1694

### DIFF
--- a/packages/message-broker/package.json
+++ b/packages/message-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esss-swap/duo-message-broker",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "author": "SWAP",
   "license": "ISC",


### PR DESCRIPTION
## Description

Add broadcasting feature for duo-messagebroker

## Motivation and Context

Many services will want to listen to the same messages, this PR allows for multiple consumers to listen to the broadcasting exchange "useroffice.fanout"

## How Has This Been Tested

import { RabbitMQMessageBroker } from '../src/index';

async function start() {
  const rabbitMq = new RabbitMQMessageBroker();

  await rabbitMq.setup({
    hostname: 'localhost',
    username: 'guest',
    password: 'guest',
  });
  rabbitMq.listenOnBroadcast(async (type, message: unknown) => {
    console.log(type, message);
  });

  await rabbitMq.sendBroadcast('Broadcast', JSON.stringify('HELLO world'));
}
start();

