### PR TITLE
SWAP-1277-use-same-validation-for-questionary-components

### DIFF
--- a/packages/message-broker/package-lock.json
+++ b/packages/message-broker/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@esss-swap/duo-message-broker",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/validation/package-lock.json
+++ b/packages/validation/package-lock.json
@@ -1,6 +1,6 @@
 {
  "name": "@esss-swap/duo-validation",
- "version": "2.0.5",
+ "version": "2.0.6",
  "lockfileVersion": 1,
  "requires": true,
  "dependencies": {
@@ -17,11 +17,94 @@
    "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
    "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg=="
   },
+  "@types/sanitize-html": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.3.2.tgz",
+   "integrity": "sha512-DnmoXsiqG2/RoSf6/lD3Hrs+TCM8ILtzNuuSjmOtRaP/ud9Sy3M3ctwD+SB50EIDs5GzVFF1dJk2Fq/ID/PNCQ==",
+   "dev": true,
+   "requires": {
+    "htmlparser2": "^6.0.0"
+   }
+  },
   "@types/yup": {
    "version": "0.29.11",
    "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.29.11.tgz",
    "integrity": "sha512-9cwk3c87qQKZrT251EDoibiYRILjCmxBvvcb4meofCmx1vdnNcR9gyildy5vOHASpOKMsn42CugxUvcwK5eu1g==",
    "dev": true
+  },
+  "colorette": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+   "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+  },
+  "deepmerge": {
+   "version": "4.2.2",
+   "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+   "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+  },
+  "dom-serializer": {
+   "version": "1.3.2",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+   "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+   "requires": {
+    "domelementtype": "^2.0.1",
+    "domhandler": "^4.2.0",
+    "entities": "^2.0.0"
+   }
+  },
+  "domelementtype": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+   "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+  },
+  "domhandler": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+   "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+   "requires": {
+    "domelementtype": "^2.2.0"
+   }
+  },
+  "domutils": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+   "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+   "requires": {
+    "dom-serializer": "^1.0.1",
+    "domelementtype": "^2.2.0",
+    "domhandler": "^4.2.0"
+   }
+  },
+  "entities": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+   "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+  },
+  "escape-string-regexp": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+   "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+  },
+  "htmlparser2": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+   "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+   "requires": {
+    "domelementtype": "^2.0.1",
+    "domhandler": "^4.0.0",
+    "domutils": "^2.5.2",
+    "entities": "^2.0.0"
+   }
+  },
+  "is-plain-object": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+   "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+  },
+  "klona": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+   "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
   },
   "lodash": {
    "version": "4.17.21",
@@ -43,6 +126,26 @@
    "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
    "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
   },
+  "nanoid": {
+   "version": "3.1.23",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+   "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+  },
+  "parse-srcset": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+   "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
+  },
+  "postcss": {
+   "version": "8.3.5",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
+   "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+   "requires": {
+    "colorette": "^1.2.2",
+    "nanoid": "^3.1.23",
+    "source-map-js": "^0.6.2"
+   }
+  },
   "property-expr": {
    "version": "2.0.4",
    "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.4.tgz",
@@ -52,6 +155,25 @@
    "version": "0.13.7",
    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
    "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+  },
+  "sanitize-html": {
+   "version": "2.4.0",
+   "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.4.0.tgz",
+   "integrity": "sha512-Y1OgkUiTPMqwZNRLPERSEi39iOebn2XJLbeiGOBhaJD/yLqtLGu6GE5w7evx177LeGgSE+4p4e107LMiydOf6A==",
+   "requires": {
+    "deepmerge": "^4.2.2",
+    "escape-string-regexp": "^4.0.0",
+    "htmlparser2": "^6.0.0",
+    "is-plain-object": "^5.0.0",
+    "klona": "^2.0.3",
+    "parse-srcset": "^1.0.2",
+    "postcss": "^8.0.2"
+   }
+  },
+  "source-map-js": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+   "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
   },
   "toposort": {
    "version": "2.0.2",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esss-swap/duo-validation",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Duo frontend and backend validation in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -30,9 +30,11 @@
   ],
   "dependencies": {
     "moment": "^2.29.0",
-    "yup": "^0.32.9"
+    "yup": "^0.32.9",
+    "sanitize-html": "^2.4.0"
   },
   "devDependencies": {
-    "@types/yup": "^0.29.0"
+    "@types/yup": "^0.29.0",
+    "@types/sanitize-html": "^2.3.2"
   }
 }

--- a/packages/validation/src/Questionary/boolean.ts
+++ b/packages/validation/src/Questionary/boolean.ts
@@ -1,0 +1,13 @@
+import * as Yup from 'yup';
+
+export const booleanQuestionValidationSchema = (field: any) => {
+  let schema = Yup.bool();
+
+  const config = field.config;
+  config.required &&
+    (schema = schema
+      .oneOf([true], 'This field is required')
+      .required('This field is required'));
+
+  return schema;
+};

--- a/packages/validation/src/Questionary/date.ts
+++ b/packages/validation/src/Questionary/date.ts
@@ -1,0 +1,49 @@
+import * as Yup from 'yup';
+
+function normalizeDate(date: string | Date) {
+  const normalizedDate = new Date(date);
+  normalizedDate.setHours(0, 0, 0, 0);
+
+  return normalizedDate;
+}
+
+export const dateQuestionValidationSchema = (field: any) => {
+  const options: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  };
+  let schema = Yup.date().nullable().typeError('Invalid Date Format');
+  const config = field.config;
+
+  config.required && (schema = schema.required('This field is required'));
+
+  schema = Yup.date().transform(function (value: Date) {
+    return normalizeDate(value);
+  });
+
+  if (config.minDate) {
+    const minDate = normalizeDate(config.minDate);
+
+    schema = schema.min(
+      minDate,
+      `Date must be no earlier than ${new Date(minDate).toLocaleDateString(
+        'en-GB',
+        options
+      )}`
+    );
+  }
+
+  if (config.maxDate) {
+    const maxDate = normalizeDate(config.maxDate);
+    schema = schema.max(
+      maxDate,
+      `Date must be no latter than ${new Date(maxDate).toLocaleDateString(
+        'en-GB',
+        options
+      )}`
+    );
+  }
+
+  return schema;
+};

--- a/packages/validation/src/Questionary/fileUpload.ts
+++ b/packages/validation/src/Questionary/fileUpload.ts
@@ -1,0 +1,15 @@
+import * as Yup from 'yup';
+
+export const fileUploadQuestionValidationSchema = (field: any) => {
+  const config = field.config;
+
+  let schema = Yup.array().of(Yup.object({ id: Yup.string().required() }));
+
+  config.required &&
+    (schema = schema.required('This is a required field').min(1));
+
+  config.max_files &&
+    (schema = schema.max(config.max_files, `Max ${config.max} files`));
+
+  return schema;
+};

--- a/packages/validation/src/Questionary/index.ts
+++ b/packages/validation/src/Questionary/index.ts
@@ -1,0 +1,7 @@
+export * from './boolean';
+export * from './date';
+export * from './fileUpload';
+export * from './interval';
+export * from './numberInput';
+export * from './richTextInput';
+export * from './textInput';

--- a/packages/validation/src/Questionary/interval.ts
+++ b/packages/validation/src/Questionary/interval.ts
@@ -1,0 +1,30 @@
+import * as Yup from 'yup';
+
+export const intervalQuestionValidationSchema = (field: any) => {
+  const config = field.config;
+
+  let minSchema = Yup.number().transform((value) =>
+    isNaN(value) ? undefined : value
+  );
+  let maxSchema = Yup.number().transform((value) =>
+    isNaN(value) ? undefined : value
+  );
+
+  if (config.required) {
+    minSchema = minSchema.required('This is a required field');
+    maxSchema = maxSchema.required('This is a required field');
+  }
+
+  let unitSchema = Yup.string().nullable();
+
+  // available units are specified and the field is required
+  if (config.units?.length && config.required) {
+    unitSchema = unitSchema.required();
+  }
+
+  return Yup.object().shape({
+    min: minSchema,
+    max: maxSchema,
+    unit: unitSchema,
+  });
+};

--- a/packages/validation/src/Questionary/numberInput.ts
+++ b/packages/validation/src/Questionary/numberInput.ts
@@ -1,0 +1,36 @@
+import * as Yup from 'yup';
+
+export const numberInputQuestionValidationSchema = (
+  field: any,
+  NumberValueConstraint: any
+) => {
+  const config = field.config;
+
+  let valueScheme = Yup.number().transform((value: any) =>
+    isNaN(value) ? undefined : value
+  );
+
+  if (config.required) {
+    valueScheme = valueScheme.required('This is a required field');
+  }
+
+  if (config.numberValueConstraint === NumberValueConstraint.ONLY_NEGATIVE) {
+    valueScheme = valueScheme.negative('Value must be a negative number');
+  }
+
+  if (config.numberValueConstraint === NumberValueConstraint.ONLY_POSITIVE) {
+    valueScheme = valueScheme.positive('Value must be a positive number');
+  }
+
+  let unitScheme = Yup.string().nullable();
+
+  // available units are specified and the field is required
+  if (config.units?.length && config.required) {
+    unitScheme = unitScheme.required('Please specify unit');
+  }
+
+  return Yup.object().shape({
+    value: valueScheme,
+    unit: unitScheme,
+  });
+};

--- a/packages/validation/src/Questionary/richTextInput.ts
+++ b/packages/validation/src/Questionary/richTextInput.ts
@@ -1,0 +1,52 @@
+import sanitizeHtml, { IOptions } from 'sanitize-html';
+import * as Yup from 'yup';
+
+// options to remove all html tags and get only text characters count
+const sanitizerValidationConfig: IOptions = {
+  allowedTags: [],
+  disallowedTagsMode: 'discard',
+  allowedAttributes: {},
+  allowedStyles: {},
+  selfClosing: [],
+  allowedSchemes: [],
+  allowedSchemesByTag: {},
+  allowedSchemesAppliedToAttributes: [],
+};
+
+const sanitizeHtmlAndCleanText = (htmlString: string) => {
+  const sanitized = sanitizeHtml(htmlString, sanitizerValidationConfig);
+
+  /**
+   * NOTE:
+   * 1. Remove all newline characters from counting.
+   * 2. Replace the surrogate pairs(emojis) with _ and count them as one character instead of two ("😀".length = 2).
+   *    https://stackoverflow.com/questions/31986614/what-is-a-surrogate-pair
+   */
+  const sanitizedCleaned = sanitized
+    .replace(/(\r\n|\n|\r)/gm, '')
+    .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_')
+    .trim();
+
+  return sanitizedCleaned;
+};
+
+export const richTextInputQuestionValidationSchema = (field: any) => {
+  let schema = Yup.string().transform(function (value: string) {
+    return sanitizeHtmlAndCleanText(value);
+  });
+
+  const config = field.config;
+
+  if (config.required) {
+    schema = schema.required('This is a required field');
+  }
+
+  if (config.max) {
+    schema = schema.max(
+      config.max,
+      `Value must be at most ${config.max} characters`
+    );
+  }
+
+  return schema;
+};

--- a/packages/validation/src/Questionary/textInput.ts
+++ b/packages/validation/src/Questionary/textInput.ts
@@ -1,0 +1,19 @@
+import * as Yup from 'yup';
+
+export const textInputQuestionValidationSchema = (field: any) => {
+  let schema = Yup.string();
+  const config = field.config;
+  config.required && (schema = schema.required('This is a required field'));
+  config.min &&
+    (schema = schema.min(
+      config.min,
+      `Value must be at least ${config.min} characters`
+    ));
+  config.max &&
+    (schema = schema.max(
+      config.max,
+      `Value must be at most ${config.max} characters`
+    ));
+
+  return schema;
+};

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -9,6 +9,7 @@ export * from './Template';
 export * from './User';
 export * from './Instrument';
 export * from './ScheduledEvent';
+export * from './Questionary';
 
 import * as util from './util';
 


### PR DESCRIPTION
## Description

feat(questionaries): Same questions validation for both frontend and backend

## Motivation and Context

Previously the validation for question components was kept in the frontend and backend separately and it wasn't aligned.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1277

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
