### PR TITLE
feat: handle events in logger

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -7,6 +7,7 @@ export enum LEVEL {
   ERROR = 'ERROR',
   EXCEPTION = 'EXCEPTION',
   FATAL = 'FATAL',
+  EVENT = 'EVENT',
 }
 
 class GrayLogLogger implements Logger {
@@ -80,6 +81,13 @@ class GrayLogLogger implements Logger {
       this.logError(message, context || {});
     }
   }
+
+  logEvent(json: string) {
+    this.log.info('EVENT', {
+      levelStr: LEVEL.EVENT,
+      context: json,
+    });
+  }
 }
 
 class ConsoleLogger implements Logger {
@@ -119,6 +127,10 @@ class ConsoleLogger implements Logger {
     }
   }
 
+  logEvent(json: string) {
+    console.log(`[${new Date().toISOString()}] ${LEVEL.EVENT} - ${json}`);
+  }
+
   log(level: LEVEL, message: string, context: Record<string, unknown>) {
     console.log(
       `[${new Date().toISOString()}] ${level} - ${message} \n ${safeStringify(
@@ -138,6 +150,7 @@ export interface Logger {
     exception: unknown,
     context?: Record<string, unknown>
   ): void;
+  logEvent(json: string): void;
 }
 
 class LoggerFactory {


### PR DESCRIPTION
## Description

This change means that events are handled by the logger, instead of logging directly to the console. 

<!--- Describe your changes in detail -->

## Motivation and Context

This was made on the back of a suggestion from this PR https://github.com/UserOfficeProject/user-office-backend/pull/496 (changes the event log format slightly). The suggestion was to use the logger to log events, instead of always logging to console.

## How Has This Been Tested

Only tested ConsoleLogger. Unable to test GrayLogLogger
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Refs https://github.com/UserOfficeProject/user-office-backend/pull/496

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
