### PR TITLE
Remove sensitive log info

### DIFF
--- a/packages/uows-client-generator/package-lock.json
+++ b/packages/uows-client-generator/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stfc-user-programme/uows_client_generator",
-	"version": "1.0.15",
+	"version": "2.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -411,6 +411,15 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
+			}
+		},
+		"@esss-swap/duo-logger": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@esss-swap/duo-logger/-/duo-logger-1.1.1.tgz",
+			"integrity": "sha512-PVGWoy/44Ck4p6mkTWvnNXMNizP7hjlXU4eWb4NQ1M6lpqZ8dP0HmFslDp+qunqxZXrpRKsRK3oS34MInWdWjg==",
+			"requires": {
+				"fast-safe-stringify": "^2.1.1",
+				"gelf-pro": "^1.3.5"
 			}
 		},
 		"@istanbuljs/load-nyc-config": {
@@ -930,6 +939,14 @@
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
+		},
+		"async": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"requires": {
+				"lodash": "^4.17.14"
+			}
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -2077,6 +2094,11 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+		},
 		"fb-watchman": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -2212,6 +2234,22 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
+		},
+		"gelf-pro": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/gelf-pro/-/gelf-pro-1.3.6.tgz",
+			"integrity": "sha512-56mK0FvzgUhIWnNSaeP4leTUOJGt9beGdIiYQWOVdafcDXiemWhEpPcOpakRV9RVj0KQf3pal575YOODahYGoA==",
+			"requires": {
+				"async": "~2.6.3",
+				"lodash": "~4.17.21"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+				}
+			}
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -3587,8 +3625,7 @@
 		"lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-			"dev": true
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",

--- a/packages/uows-client-generator/package-lock.json
+++ b/packages/uows-client-generator/package-lock.json
@@ -750,6 +750,15 @@
 			"integrity": "sha512-uD0j/AQOa5le7afuK+u+woi8jNKF1vf3DN0H7LCJhft/lNNibUr7VcAesdgtWfEKveZol3ZG1CJqwx2Bhrnl8w==",
 			"dev": true
 		},
+		"@types/sax": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.3.tgz",
+			"integrity": "sha512-+QSw6Tqvs/KQpZX8DvIl3hZSjNFLW/OqE5nlyHXtTwODaJvioN2rOWpBNEWZp2HZUFhOh+VohmJku/WxEXU2XA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/stack-utils": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",

--- a/packages/uows-client-generator/package.json
+++ b/packages/uows-client-generator/package.json
@@ -35,9 +35,10 @@
     "uows-client-generator": "lib/index/index.js"
   },
   "devDependencies": {
-    "@types/yargs": "^15.0.11",
     "@types/jest": "^26.0.17",
     "@types/rewire": "^2.5.28",
+    "@types/sax": "^1.2.3",
+    "@types/yargs": "^15.0.11",
     "jest": "^26.6.3",
     "rewire": "^5.0.0",
     "ts-jest": "^26.4.4"

--- a/packages/uows-client-generator/package.json
+++ b/packages/uows-client-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stfc-user-programme/uows_client_generator",
-  "version": "1.0.15",
+  "version": "2.0.0",
   "description": "Generates an interface for consumning the User Office Web Service",
   "main": "lib/index/index.js",
   "author": "STFC",
@@ -26,6 +26,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@esss-swap/duo-logger": "^1.1.1",
     "soap": "^0.40.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.4.3",

--- a/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
+++ b/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
@@ -46,6 +46,17 @@ export const createFunctTemplate = (
                       return client['${functName}Async'](argsObj);
                   }).then(result => {
                       return result[0];
+                  }).catch(result => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: '${functName}',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
                   });
                   return refinedResult;
               }\n\n`;

--- a/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
+++ b/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
@@ -41,8 +41,8 @@ export const createFunctTemplate = (
   if (argDetails.length > 0) makeArgObjArgs = ', ' + makeArgObjArgs;
 
   return `    public async ${functName}(${wrapperArgString}) : Promise<any> {
-                  let refinedResult = soap.createClientAsync(this.wsdlUrl).then((client: soap.Client) => {
-                      let argsObj = this.makeArgsObj('${functName}'${makeArgObjArgs});
+                  const refinedResult = soap.createClientAsync(this.wsdlUrl).then((client: soap.Client) => {
+                      const argsObj = this.makeArgsObj('${functName}'${makeArgObjArgs});
                       return client['${functName}Async'](argsObj);
                   }).then(result => {
                       return result[0];
@@ -56,11 +56,11 @@ export const makeArgsObjTemplate: string = `   private makeArgsObj(functName: st
               const argsObj : {[key: string]: any} = {};
               const serviceDesc = this.wsdlDesc[Object.keys(this.wsdlDesc)[0]];
               const collectionOfFunctions = serviceDesc[Object.keys(serviceDesc)[0]];
-              let argsDescr = collectionOfFunctions[functName];
+              const argsDescr = collectionOfFunctions[functName];
   
               Object.keys(argsDescr.input).forEach((element: string, index: number) => {
                   if (element !== 'targetNSAlias' && element !== 'targetNamespace') {
-                      let argName: string = element.replace('[]', '');
+                      const argName: string = element.replace('[]', '');
                       argsObj[argName] = args[index];
                   }
               });

--- a/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
+++ b/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
@@ -40,11 +40,11 @@ export const createFunctTemplate = (
 
   if (argDetails.length > 0) makeArgObjArgs = ', ' + makeArgObjArgs;
 
-  return `    public ${functName}(${wrapperArgString}): any {
-                  let refinedResult: any = soap.createClientAsync(this.wsdlUrl).then((client: soap.Client) => {
-                      let argsObj: any = this.makeArgsObj('${functName}'${makeArgObjArgs});
+  return `    public async ${functName}(${wrapperArgString}) : Promise<any> {
+                  let refinedResult = soap.createClientAsync(this.wsdlUrl).then((client: soap.Client) => {
+                      let argsObj = this.makeArgsObj('${functName}'${makeArgObjArgs});
                       return client['${functName}Async'](argsObj);
-                  }).then((result: any) => {
+                  }).then(result => {
                       return result[0];
                   });
                   return refinedResult;
@@ -52,11 +52,11 @@ export const createFunctTemplate = (
 };
 
 //A string specifying a function for constructing an object from user-provided parameters for use by in SOAP function calls
-export const makeArgsObjTemplate: string = `   private makeArgsObj(functName: string, ...args: any[]): any {
-              const argsObj: any = {};
-              const serviceDesc: any = this.wsdlDesc[Object.keys(this.wsdlDesc)[0]];
-              const collectionOfFunctions: any = serviceDesc[Object.keys(serviceDesc)[0]];
-              let argsDescr: any = collectionOfFunctions[functName];
+export const makeArgsObjTemplate: string = `   private makeArgsObj(functName: string, ...args: any[]) {
+              const argsObj : {[key: string]: any} = {};
+              const serviceDesc = this.wsdlDesc[Object.keys(this.wsdlDesc)[0]];
+              const collectionOfFunctions = serviceDesc[Object.keys(serviceDesc)[0]];
+              let argsDescr = collectionOfFunctions[functName];
   
               Object.keys(argsDescr.input).forEach((element: string, index: number) => {
                   if (element !== 'targetNSAlias' && element !== 'targetNamespace') {

--- a/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
+++ b/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
@@ -41,15 +41,14 @@ export const createFunctTemplate = (
   if (argDetails.length > 0) makeArgObjArgs = ', ' + makeArgObjArgs;
 
   return `    public ${functName}(${wrapperArgString}): any {
-                      let refinedResult: any =
-                      soap.createClientAsync(this.wsdlUrl).then((client: soap.Client) => {
-                          let argsObj: any = this.makeArgsObj('${functName}'${makeArgObjArgs});
-                          return client['${functName}Async'](argsObj);
-                      }).then((result: any) => {
-                          return result[0];
-                      });
-                      return refinedResult;
-                  }\n\n`;
+                  let refinedResult: any = soap.createClientAsync(this.wsdlUrl).then((client: soap.Client) => {
+                      let argsObj: any = this.makeArgsObj('${functName}'${makeArgObjArgs});
+                      return client['${functName}Async'](argsObj);
+                  }).then((result: any) => {
+                      return result[0];
+                  });
+                  return refinedResult;
+              }\n\n`;
 };
 
 //A string specifying a function for constructing an object from user-provided parameters for use by in SOAP function calls

--- a/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
+++ b/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
@@ -47,10 +47,7 @@ export const createFunctTemplate = (
                           return client['${functName}Async'](argsObj);
                       }).then((result: any) => {
                           return result[0];
-                      }).catch((err: any) => {
-                          console.error(err);
                       });
-  
                       return refinedResult;
                   }\n\n`;
 };

--- a/packages/uows-client-generator/src/index/index.ts
+++ b/packages/uows-client-generator/src/index/index.ts
@@ -37,6 +37,7 @@ const getArgs = () => {
 const generateCode = (obj: any, wsdl: string, filePath: string): void => {
   fs.writeFileSync(filePath, `
     import * as soap from 'soap';
+    import { logger } from '@esss-swap/duo-logger';
 
     export default class UOWSSoapClient {
       private wsdlUrl: string;

--- a/packages/uows-client-generator/src/index/index.ts
+++ b/packages/uows-client-generator/src/index/index.ts
@@ -35,21 +35,20 @@ const getArgs = () => {
 
 //Writes the UOWSSoapInterface.ts file to storage
 const generateCode = (obj: any, wsdl: string, filePath: string): void => {
-  /*eslint quotes: ["error", "single", { "avoidEscape": true }]*/
-  fs.writeFileSync(filePath, "import * as soap from 'soap';\n\n");
-  fs.appendFileSync(filePath, 'export default class UOWSSoapClient {\n\n');
-  fs.appendFileSync(filePath, 'private wsdlUrl: string;\n');
-  fs.appendFileSync(
-    filePath,
-    `private wsdlDesc: any = ${JSON.stringify(wsdlDesc)};\n\n`
-  );
-  fs.appendFileSync(filePath, constructorTemplate(wsdl));
+  fs.writeFileSync(filePath, `
+    import * as soap from 'soap';
 
-  Object.keys(obj).forEach((element: string) => {
-    fs.appendFileSync(filePath, obj[element]);
-  });
+    export default class UOWSSoapClient {
+      private wsdlUrl: string;
+      private wsdlDesc: any = ${JSON.stringify(wsdlDesc)};
 
-  fs.appendFileSync(filePath, `${makeArgsObjTemplate}\n}`);
+      ${constructorTemplate(wsdl)}
+
+      ${Object.keys(obj).map(element => obj[element]).join("")}
+
+      ${makeArgsObjTemplate}
+    }
+  `);
 };
 
 //Creates the UOWSService.ts file


### PR DESCRIPTION
Part of UserOfficeProject/stfc-user-office-project#231

## Description
Best reviewed by commit, as there have been a few refactorings to make working with the generator easier.

Before this PR, all generated functions for UOWS methods would silently log the whole response object on error. The response object contains an enormous amount of data, including the API key used for the request. The vast majority of the data is also useless for debugging purposes and only makes it harder to spot the actual error.

This PR changes the generated functions to make them log only a small, but useful amount of the response data. The client also tries to do some basic parsing of the XML response to give the caller a useful error message. The client also rethrows the error after logging it, letting the caller know that something went wrong (it would previously fail silently). This is a breaking change, as functions now need to catch any expected errors instead of checking for a `null` result.

## Motivation and Context
The main motivation for this is to avoid logging the API key on every webservice error. It also makes error handling more reliable.

## How Has This Been Tested
Unit tests and manually by simulating problems with the webservice.

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
