### PR TITLE
performance: Speed up UOWS client

### DIFF
--- a/packages/uows-client-generator/__mocks__/soap.ts
+++ b/packages/uows-client-generator/__mocks__/soap.ts
@@ -1,6 +1,6 @@
 const soap: any = {};
 
-const serviceMock: any = {
+const serviceMock = {
   getAgeRangeOptionsAsync: async function () {
     return new Promise<any>((resolve) => {
       resolve(['1-99']);
@@ -13,12 +13,11 @@ const serviceMock: any = {
   },
 };
 
-const createClientAsync = async (): Promise<any> => {
-  return new Promise<any>((resolve) => {
-    resolve(serviceMock);
-  });
+soap.createClient = (
+  url: string,
+  callback: (error: any, client: any) => void
+) => {
+  callback(null, serviceMock);
 };
-
-soap.createClientAsync = createClientAsync;
 
 module.exports = soap;

--- a/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
+++ b/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
@@ -41,12 +41,10 @@ export const createFunctTemplate = (
   if (argDetails.length > 0) makeArgObjArgs = ', ' + makeArgObjArgs;
 
   return `    public async ${functName}(${wrapperArgString}) : Promise<any> {
-                  const refinedResult = soap.createClientAsync(this.wsdlUrl).then((client: soap.Client) => {
-                      const argsObj = this.makeArgsObj('${functName}'${makeArgObjArgs});
-                      return client['${functName}Async'](argsObj);
-                  }).then(result => {
+                  const argsObj = this.makeArgsObj('${functName}'${makeArgObjArgs});
+                  const refinedResult = this.client['${functName}Async'](argsObj).then((result: any) => {
                       return result[0];
-                  }).catch(result => {
+                  }).catch((result: any) => {
                       const response = result?.response;
                       const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
                       logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
@@ -85,5 +83,12 @@ export const constructorTemplate = (wsdl: string) => {
                   this.wsdlUrl = '${wsdl}';
               else
                   this.wsdlUrl = wsdlUrl;
+
+              soap.createClient(this.wsdlUrl, (error, client) => {
+                if (error) {
+                  logger.logError('An error occurred while creating the UOWS client', {error: error});
+                }
+                this.client = client
+              });
           }\n\n`;
 };

--- a/packages/uows-client-generator/src/index/index.ts
+++ b/packages/uows-client-generator/src/index/index.ts
@@ -43,6 +43,7 @@ const generateCode = (obj: any, wsdl: string, filePath: string): void => {
 
     export default class UOWSSoapClient {
       private wsdlUrl: string;
+      private client!: soap.Client;
       private wsdlDesc: any = ${JSON.stringify(wsdlDesc)};
 
       ${constructorTemplate(wsdl)}

--- a/packages/uows-client-generator/src/index/index.ts
+++ b/packages/uows-client-generator/src/index/index.ts
@@ -40,10 +40,12 @@ const generateCode = (obj: any, wsdl: string, filePath: string): void => {
     `
     import * as soap from 'soap';
     import { logger } from '@user-office-software/duo-logger';
+    import { createHash } from 'crypto';
 
     export default class UOWSSoapClient {
       private wsdlUrl: string;
       private client!: soap.Client;
+      private activeUowsRequests: Record<string, Promise<any>> = {};
       private wsdlDesc: any = ${JSON.stringify(wsdlDesc)};
 
       ${constructorTemplate(wsdl)}


### PR DESCRIPTION
## Description
The main point of this PR is to reduce the amount of calls made to the UOWS client.

The main changes are using a single instance of `soap.Client` to make all calls, and caching in-progress `Promise`s so that concurrent requests for the same method, with the same arguments, don't need a separate UOWS call for each request. See each commit's description for more information on these changes and why I made them.

Thanks to @WHTaylor for the idea of caching Promises to avoid repeated requests.

## Motivation and Context
If the UOWS gets too many requests at the same time, it eventually stops responding and user token can no longer be verified. This leads to users being logged out of the app.

## How Has This Been Tested
- Unit tests
- Manual tests of the backend/frontend in STFC mode

## Fixes
Part of https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/580

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
