### PR TITLE
performance: Make UOWS client a singleton class

### DIFF
--- a/packages/uows-client-generator/package-lock.json
+++ b/packages/uows-client-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@user-office-software/uows_client_generator",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@user-office-software/uows_client_generator",
-      "version": "2.4.1",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@user-office-software/duo-logger": "^1.1.3",

--- a/packages/uows-client-generator/package-lock.json
+++ b/packages/uows-client-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@user-office-software/uows_client_generator",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@user-office-software/uows_client_generator",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "ISC",
       "dependencies": {
         "@user-office-software/duo-logger": "^1.1.3",

--- a/packages/uows-client-generator/package.json
+++ b/packages/uows-client-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/uows_client_generator",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "Generates an interface for consuming the User Office Web Service",
   "main": "lib/index/index.js",
   "author": "STFC",

--- a/packages/uows-client-generator/package.json
+++ b/packages/uows-client-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/uows_client_generator",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Generates an interface for consuming the User Office Web Service",
   "main": "lib/index/index.js",
   "author": "STFC",

--- a/packages/uows-client-generator/src/UOWSServiceClient/UOWSServiceClient.spec.ts
+++ b/packages/uows-client-generator/src/UOWSServiceClient/UOWSServiceClient.spec.ts
@@ -7,14 +7,14 @@ afterAll(() => {
 });
 
 test('Should return age range result from mocked soap module', async () => {
-  const client: UOWSSoapClient = new UOWSSoapClient();
+  const client: UOWSSoapClient = UOWSSoapClient.getInstance();
   const result: any = await client.getAgeRangeOptions();
 
   expect(result).toBe('1-99');
 });
 
 test('Should return establishment details result from mocked soap module', async () => {
-  const client: UOWSSoapClient = new UOWSSoapClient();
+  const client: UOWSSoapClient = UOWSSoapClient.getInstance();
 
   const searchDetails: any[] = [
     {

--- a/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
+++ b/packages/uows-client-generator/src/construct-functions/constructFunctions.ts
@@ -89,7 +89,7 @@ export const makeArgsObjTemplate: string = `   private makeArgsObj(functName: st
 
 //A string specifying the constructor for the UOWSSoapInterface class
 export const constructorTemplate = (wsdl: string) => {
-  return `   public constructor(wsdlUrl?: string) {
+  return `   private constructor(wsdlUrl?: string) {
               if(wsdlUrl == null)
                   this.wsdlUrl = '${wsdl}';
               else

--- a/packages/uows-client-generator/src/index/index.ts
+++ b/packages/uows-client-generator/src/index/index.ts
@@ -43,10 +43,19 @@ const generateCode = (obj: any, wsdl: string, filePath: string): void => {
     import { createHash } from 'crypto';
 
     export default class UOWSSoapClient {
+      private static instance: UOWSSoapClient | undefined = undefined;
       private wsdlUrl: string;
       private client!: soap.Client;
       private activeUowsRequests: Map<string, Promise<any>> = new Map();
       private wsdlDesc: any = ${JSON.stringify(wsdlDesc)};
+
+      static getInstance(): UOWSSoapClient {
+        if (!this.instance) {
+          this.instance = new UOWSSoapClient(process.env.EXTERNAL_AUTH_SERVICE_URL);
+        }
+
+        return this.instance;
+      }
 
       ${constructorTemplate(wsdl)}
 


### PR DESCRIPTION
## Description
This ensures that consumers can only create a single instance of the UOWS client. The advantage of doing this is that the promise cache introduced in https://github.com/UserOfficeProject/user-office-lib/pull/131  can be used more effectively, as all requests will go through a single client and can be merged if they're identical. We also make ensure that the WSDL is only fetched once and reduce memory usage, as there will not be multiple clients each fetching, parsing and storing the WSDL of the service. This may also make debugging easier, as there is a now single component connecting to the external service rather than many.

The downside of this is that we can't have two UOWS clients for different URLs in the same application. I can't think of a situation where we'd want to do that, so I think the performance and ease of debugging are worth it.

I've increased the major version number to show that this is a breaking change, as all consumers will have to switch from using `new UOWSSoapClient()` to `UOWSSoapClient.getInstance()` to get an instance of the client.

## Motivation and Context
The proposals backend currently uses 2 different clients for talking to the UOWS (one fot the authorization checks and one for the user datasource), and I would like to merge them into one.

## How Has This Been Tested
By installing the new version in the backend locally and checking pages which display user data.

## Fixes
Part of https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/580

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
