### PR TITLE
112, add internal call end date validation

### DIFF
--- a/packages/message-broker/package-lock.json
+++ b/packages/message-broker/package-lock.json
@@ -1,336 +1,336 @@
 {
-  "name": "@user-office-software/duo-message-broker",
-  "version": "1.4.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "@user-office-software/duo-message-broker",
-      "version": "1.4.0",
-      "license": "ISC",
-      "dependencies": {
-        "@types/amqplib": "^0.8.2",
-        "@user-office-software/duo-logger": "^1.1.3",
-        "amqplib": "^0.10.3"
-      },
-      "engines": {
-        "node": ">=16.14.0",
-        "npm": ">=8.5.0"
-      }
-    },
-    "node_modules/@acuminous/bitsyntax": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
-      "integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
-      "dependencies": {
-        "buffer-more-ints": "~1.0.0",
-        "debug": "^4.3.4",
-        "safe-buffer": "~5.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/@types/amqplib": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.8.2.tgz",
-      "integrity": "sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==",
-      "dependencies": {
-        "@types/bluebird": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
-      "integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g=="
-    },
-    "node_modules/@types/node": {
-      "version": "14.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
-      "integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ=="
-    },
-    "node_modules/@user-office-software/duo-logger": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-logger/-/duo-logger-1.2.0.tgz",
-      "integrity": "sha512-/4DnoO8ehMIofExIdRrmwE7pOp40KG3PPvgV4dDDGHKz9dlmAvjARAgo46y5etw6L9ME6ZUsEkczFll0D6AQJw==",
-      "dependencies": {
-        "fast-safe-stringify": "^2.1.1",
-        "gelf-pro": "^1.3.6"
-      }
-    },
-    "node_modules/amqplib": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
-      "integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
-      "dependencies": {
-        "@acuminous/bitsyntax": "^0.1.2",
-        "buffer-more-ints": "~1.0.0",
-        "readable-stream": "1.x >=1.1.9",
-        "url-parse": "~1.5.10"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/buffer-more-ints": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
-      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
-    },
-    "node_modules/gelf-pro": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/gelf-pro/-/gelf-pro-1.3.6.tgz",
-      "integrity": "sha512-56mK0FvzgUhIWnNSaeP4leTUOJGt9beGdIiYQWOVdafcDXiemWhEpPcOpakRV9RVj0KQf3pal575YOODahYGoA==",
-      "dependencies": {
-        "async": "~2.6.3",
-        "lodash": "~4.17.21"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
-    "node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@acuminous/bitsyntax": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
-      "integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
-      "requires": {
-        "buffer-more-ints": "~1.0.0",
-        "debug": "^4.3.4",
-        "safe-buffer": "~5.1.2"
-      }
-    },
-    "@types/amqplib": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.8.2.tgz",
-      "integrity": "sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==",
-      "requires": {
-        "@types/bluebird": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/bluebird": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
-      "integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g=="
-    },
-    "@types/node": {
-      "version": "14.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
-      "integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ=="
-    },
-    "@user-office-software/duo-logger": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-logger/-/duo-logger-1.2.0.tgz",
-      "integrity": "sha512-/4DnoO8ehMIofExIdRrmwE7pOp40KG3PPvgV4dDDGHKz9dlmAvjARAgo46y5etw6L9ME6ZUsEkczFll0D6AQJw==",
-      "requires": {
-        "fast-safe-stringify": "^2.1.1",
-        "gelf-pro": "^1.3.6"
-      }
-    },
-    "amqplib": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
-      "integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
-      "requires": {
-        "@acuminous/bitsyntax": "^0.1.2",
-        "buffer-more-ints": "~1.0.0",
-        "readable-stream": "1.x >=1.1.9",
-        "url-parse": "~1.5.10"
-      }
-    },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "buffer-more-ints": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
-      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
-    },
-    "gelf-pro": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/gelf-pro/-/gelf-pro-1.3.6.tgz",
-      "integrity": "sha512-56mK0FvzgUhIWnNSaeP4leTUOJGt9beGdIiYQWOVdafcDXiemWhEpPcOpakRV9RVj0KQf3pal575YOODahYGoA==",
-      "requires": {
-        "async": "~2.6.3",
-        "lodash": "~4.17.21"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    }
-  }
+	"name": "@user-office-software/duo-message-broker",
+	"version": "1.4.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@user-office-software/duo-message-broker",
+			"version": "1.4.0",
+			"license": "ISC",
+			"dependencies": {
+				"@types/amqplib": "^0.8.2",
+				"@user-office-software/duo-logger": "^1.1.3",
+				"amqplib": "^0.10.3"
+			},
+			"engines": {
+				"node": ">=16.14.0",
+				"npm": ">=8.5.0"
+			}
+		},
+		"node_modules/@acuminous/bitsyntax": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
+			"integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
+			"dependencies": {
+				"buffer-more-ints": "~1.0.0",
+				"debug": "^4.3.4",
+				"safe-buffer": "~5.1.2"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/@types/amqplib": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.8.2.tgz",
+			"integrity": "sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==",
+			"dependencies": {
+				"@types/bluebird": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/bluebird": {
+			"version": "3.5.32",
+			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
+			"integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g=="
+		},
+		"node_modules/@types/node": {
+			"version": "14.11.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
+			"integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ=="
+		},
+		"node_modules/@user-office-software/duo-logger": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@user-office-software/duo-logger/-/duo-logger-1.2.0.tgz",
+			"integrity": "sha512-/4DnoO8ehMIofExIdRrmwE7pOp40KG3PPvgV4dDDGHKz9dlmAvjARAgo46y5etw6L9ME6ZUsEkczFll0D6AQJw==",
+			"dependencies": {
+				"fast-safe-stringify": "^2.1.1",
+				"gelf-pro": "^1.3.6"
+			}
+		},
+		"node_modules/amqplib": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
+			"integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+			"dependencies": {
+				"@acuminous/bitsyntax": "^0.1.2",
+				"buffer-more-ints": "~1.0.0",
+				"readable-stream": "1.x >=1.1.9",
+				"url-parse": "~1.5.10"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/async": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"dependencies": {
+				"lodash": "^4.17.14"
+			}
+		},
+		"node_modules/buffer-more-ints": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+			"integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+		},
+		"node_modules/gelf-pro": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/gelf-pro/-/gelf-pro-1.3.6.tgz",
+			"integrity": "sha512-56mK0FvzgUhIWnNSaeP4leTUOJGt9beGdIiYQWOVdafcDXiemWhEpPcOpakRV9RVj0KQf3pal575YOODahYGoA==",
+			"dependencies": {
+				"async": "~2.6.3",
+				"lodash": "~4.17.21"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+		},
+		"node_modules/readable-stream": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"node_modules/string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		}
+	},
+	"dependencies": {
+		"@acuminous/bitsyntax": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
+			"integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
+			"requires": {
+				"buffer-more-ints": "~1.0.0",
+				"debug": "^4.3.4",
+				"safe-buffer": "~5.1.2"
+			}
+		},
+		"@types/amqplib": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.8.2.tgz",
+			"integrity": "sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==",
+			"requires": {
+				"@types/bluebird": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/bluebird": {
+			"version": "3.5.32",
+			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
+			"integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g=="
+		},
+		"@types/node": {
+			"version": "14.11.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
+			"integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ=="
+		},
+		"@user-office-software/duo-logger": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@user-office-software/duo-logger/-/duo-logger-1.2.0.tgz",
+			"integrity": "sha512-/4DnoO8ehMIofExIdRrmwE7pOp40KG3PPvgV4dDDGHKz9dlmAvjARAgo46y5etw6L9ME6ZUsEkczFll0D6AQJw==",
+			"requires": {
+				"fast-safe-stringify": "^2.1.1",
+				"gelf-pro": "^1.3.6"
+			}
+		},
+		"amqplib": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
+			"integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+			"requires": {
+				"@acuminous/bitsyntax": "^0.1.2",
+				"buffer-more-ints": "~1.0.0",
+				"readable-stream": "1.x >=1.1.9",
+				"url-parse": "~1.5.10"
+			}
+		},
+		"async": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"requires": {
+				"lodash": "^4.17.14"
+			}
+		},
+		"buffer-more-ints": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+			"integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+		},
+		"gelf-pro": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/gelf-pro/-/gelf-pro-1.3.6.tgz",
+			"integrity": "sha512-56mK0FvzgUhIWnNSaeP4leTUOJGt9beGdIiYQWOVdafcDXiemWhEpPcOpakRV9RVj0KQf3pal575YOODahYGoA==",
+			"requires": {
+				"async": "~2.6.3",
+				"lodash": "~4.17.21"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+		},
+		"readable-stream": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+		},
+		"url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"requires": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		}
+	}
 }

--- a/packages/validation/package-lock.json
+++ b/packages/validation/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@user-office-software/duo-validation",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@user-office-software/duo-validation",
-			"version": "3.4.0",
+			"version": "3.4.1",
 			"license": "ISC",
 			"dependencies": {
 				"luxon": "^2.5.0",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/duo-validation",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Duo frontend and backend validation in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/validation/src/Call/index.ts
+++ b/packages/validation/src/Call/index.ts
@@ -33,7 +33,7 @@ const firstStepCreateCallValidationSchema = Yup.object().shape({
 
       return schema.min(
         endCall,
-        'Internal call end date can not be before  call end date.'
+        'Internal call end date can not be before call end date.'
       );
     }),
   templateId: Yup.number().required(),

--- a/packages/validation/src/Call/index.ts
+++ b/packages/validation/src/Call/index.ts
@@ -24,6 +24,18 @@ const firstStepCreateCallValidationSchema = Yup.object().shape({
         'End call date can not be before start call date.'
       );
     }),
+  endCallInternal: Yup.date()
+    .typeError(TYPE_ERR_INVALID_DATE_TIME)
+    .when('endCall', (endCall: Date, schema: Yup.DateSchema) => {
+      if (!isValidDate(endCall)) {
+        return schema;
+      }
+
+      return schema.min(
+        endCall,
+        'Internal call end date can not be before  call end date.'
+      );
+    }),
   templateId: Yup.number().required(),
   proposalWorkflowId: Yup.number().required(),
 });


### PR DESCRIPTION
## Description
Adds new  validation to  call validation on create and update on end call internal  date .
<!--- Describe your changes in detail -->

## Motivation and Context
Users must key in a valid date and end call internal  date must not be before call end date.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Tested in local environment with changes in frontend.

![internal call test](https://user-images.githubusercontent.com/71100224/192756283-9025908a-7dc4-409c-aebd-cec5317d8326.JPG)

![test call end internal](https://user-images.githubusercontent.com/71100224/192756674-d47abb6a-6e2d-44de-b460-41fc399ba066.JPG)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Is part of https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/112
<!--- Does this fix a user story, if so add a reference here -->

## Changes

File changed .
packages/validation/src/Call/index.ts
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->
Can be merged alone  but will be user by https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/112

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
