### PR TITLE
feat: Add bindQueueToExchange functionality to be able to bind queues to exchanges automatically

### DIFF
--- a/packages/message-broker/package-lock.json
+++ b/packages/message-broker/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@user-office-software/duo-message-broker",
-	"version": "1.4.2",
+	"version": "1.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@user-office-software/duo-message-broker",
-			"version": "1.4.2",
+			"version": "1.5.0",
 			"license": "ISC",
 			"dependencies": {
-				"@types/amqplib": "^0.8.2",
+				"@types/amqplib": "^0.10.1",
 				"amqplib": "^0.10.3"
 			},
 			"engines": {
@@ -31,18 +31,12 @@
 			}
 		},
 		"node_modules/@types/amqplib": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.8.2.tgz",
-			"integrity": "sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.1.tgz",
+			"integrity": "sha512-j6ANKT79ncUDnAs/+9r9eDujxbeJoTjoVu33gHHcaPfmLQaMhvfbH2GqSe8KUM444epAp1Vl3peVOQfZk3UIqA==",
 			"dependencies": {
-				"@types/bluebird": "*",
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/bluebird": {
-			"version": "3.5.32",
-			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
-			"integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g=="
 		},
 		"node_modules/@types/node": {
 			"version": "14.11.5",
@@ -157,18 +151,12 @@
 			}
 		},
 		"@types/amqplib": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.8.2.tgz",
-			"integrity": "sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.1.tgz",
+			"integrity": "sha512-j6ANKT79ncUDnAs/+9r9eDujxbeJoTjoVu33gHHcaPfmLQaMhvfbH2GqSe8KUM444epAp1Vl3peVOQfZk3UIqA==",
 			"requires": {
-				"@types/bluebird": "*",
 				"@types/node": "*"
 			}
-		},
-		"@types/bluebird": {
-			"version": "3.5.32",
-			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
-			"integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g=="
 		},
 		"@types/node": {
 			"version": "14.11.5",

--- a/packages/message-broker/package.json
+++ b/packages/message-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/duo-message-broker",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "",
   "author": "SWAP",
   "license": "ISC",
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/amqplib": "^0.8.2",
+    "@types/amqplib": "^0.10.1",
     "@user-office-software/duo-logger": "^2.1.1",
     "amqplib": "^0.10.3"
   },


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR adds the functionality to bind a queue to exchange automatically instead of doing it manually in the rabbitmq

## Motivation and Context

Previously you needed to manually bind the right queue to the right exchange.

## How Has This Been Tested

- manual testing

## Fixes

https://jira.esss.lu.se/browse/SWAP-3131
