### PR TITLE
fix: Fixed NaN issue during validation.

### DIFF
--- a/packages/validation/package-lock.json
+++ b/packages/validation/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@user-office-software/duo-validation",
-	"version": "3.4.6",
+	"version": "3.4.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@user-office-software/duo-validation",
-			"version": "3.4.6",
+			"version": "3.4.7",
 			"license": "ISC",
 			"dependencies": {
 				"luxon": "^2.5.0",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/duo-validation",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Duo frontend and backend validation in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/validation/src/Questionary/instrumentPicker.ts
+++ b/packages/validation/src/Questionary/instrumentPicker.ts
@@ -3,7 +3,12 @@ import * as Yup from 'yup';
 export const instrumentPickerValidationSchema = (field: any) => {
   const config = field.config;
 
-  let schema = Yup.number().positive().integer();
+  // Value can be a number or null, if not required. If required, it must be a number.
+  let schema = Yup.number()
+    .positive()
+    .integer()
+    .nullable()
+    .transform((_, val) => (val === Number(val) ? val : null)); // Need to write custom transform to allow null values, else Yup throws NaN error
 
   if (config.required) {
     schema = schema.required();


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Value can be a number or null, if not required. If required, it must be a number. Need to write custom transform to allow null values, else Yup throws NaN 

## Motivation and Context

When no options are selected, the value will be null. Yup throws NaN error, as it is unable to parse the null value. 

## How Has This Been Tested

Manual. 

## Fixes

Fixes NaN error

## Changes

Yup Transform Config. 

## Depends on

No


## Tests included/Docs Updated?

No

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
