### PR TITLE
fix: update schema should contain all optional except for id

### DIFF
--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/duo-validation",
-  "version": "3.4.12",
+  "version": "3.4.13",
   "description": "Duo frontend and backend validation in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/validation/src/Call/index.ts
+++ b/packages/validation/src/Call/index.ts
@@ -149,6 +149,36 @@ export const updateCallValidationSchemas = [
   thirdStepCallValidationSchema,
 ];
 
+export const updateCallValidationSchemaBackend = Yup.object().shape({
+  id: Yup.object()
+    .shape({
+      id: Yup.number().required('Id is required'),
+    })
+    .required(),
+  // from first step
+  shortCode: firstStepCreateCallValidationSchema.fields.shortCode.optional(),
+  startCall: firstStepCreateCallValidationSchema.fields.startCall.optional(),
+  endCall: firstStepCreateCallValidationSchema.fields.endCall.optional(),
+  endCallInternal:
+    firstStepCreateCallValidationSchema.fields.endCallInternal.optional(),
+  templateId: firstStepCreateCallValidationSchema.fields.templateId.optional(),
+  proposalWorkflowId:
+    firstStepCreateCallValidationSchema.fields.proposalWorkflowId.optional(),
+  // from second step
+  startReview: secondStepCallValidationSchema.fields.startReview.optional(),
+  endReview: secondStepCallValidationSchema.fields.endReview.optional(),
+  startSEPReview:
+    secondStepCallValidationSchema.fields.startSEPReview.optional(),
+  endSEPReview: secondStepCallValidationSchema.fields.endSEPReview.optional(),
+  surveyComment: secondStepCallValidationSchema.fields.surveyComment.optional(),
+  // from third step
+  startNotify: thirdStepCallValidationSchema.fields.startNotify.optional(),
+  endNotify: thirdStepCallValidationSchema.fields.endNotify.optional(),
+  startCycle: thirdStepCallValidationSchema.fields.startCycle.optional(),
+  endCycle: thirdStepCallValidationSchema.fields.endCycle.optional(),
+  cycleComment: thirdStepCallValidationSchema.fields.cycleComment.optional(),
+});
+
 export const assignInstrumentsToCallValidationSchema = Yup.object().shape({
   callId: Yup.number().required('callId is required'),
   instrumentIds: Yup.array(Yup.number())


### PR DESCRIPTION
## Description

When updating a call, the update request should consist of a mandatory ID, and all other fields are optional. The ones specified will be updated, and the ones not specified will not be modified

## Motivation and Context
Making backend agnostic of the UI implementation
