### PR TITLE
Add technique validation schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18683,7 +18683,7 @@
     },
     "packages/validation": {
       "name": "@user-office-software/duo-validation",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
         "luxon": "^2.5.0",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/duo-validation",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Duo frontend and backend validation in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/validation/src/Technique/index.ts
+++ b/packages/validation/src/Technique/index.ts
@@ -1,0 +1,29 @@
+import * as Yup from 'yup';
+
+export const createTechniqueValidationSchema = Yup.object().shape({
+  name: Yup.string().required(),
+  shortCode: Yup.string().required(),
+  description: Yup.string().required(),
+});
+
+export const updateTechniqueValidationSchema = Yup.object().shape({
+  id: Yup.number().required(),
+  name: Yup.string().required(),
+  shortCode: Yup.string().required(),
+  description: Yup.string().required(),
+});
+
+export const deleteTechniqueValidationSchema = Yup.object().shape({
+  id: Yup.number().required(),
+});
+
+export const assignInstrumentsToTechniqueValidationSchema = Yup.object().shape({
+  instrumentIds: Yup.array(Yup.number()).min(1).required(),
+  techniqueId: Yup.number().required(),
+});
+
+export const removeInstrumentsFromTechniqueValidationSchema =
+  Yup.object().shape({
+    instrumentId: Yup.number().required(),
+    techniqueId: Yup.number().required(),
+  });

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -14,6 +14,7 @@ export * from './ProposalBooking';
 export * from './LostTime';
 export * from './Equipment';
 export * from './Questionary';
+export * from './Technique';
 
 import * as util from './util';
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This is part of creating techniques for the STFC Xpress access route in the software. We are currently creating a new concept of techniques that have instruments attached to them (will be done via another core PR that is not yet created) and this is the validation for it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

We've tested this by temporarily moving the schemas inside the user-office-core and importing from there. Once this is merged we can update the imports.

## Fixes

Part of https://github.com/UserOfficeProject/issue-tracker/issues/1095

## Changes

Adds technique validation schemas

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
