### PR TITLE
restrict time requested to be an integer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18683,7 +18683,7 @@
     },
     "packages/validation": {
       "name": "@user-office-software/duo-validation",
-      "version": "5.1.6",
+      "version": "5.1.7",
       "license": "ISC",
       "dependencies": {
         "luxon": "^2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18683,7 +18683,7 @@
     },
     "packages/validation": {
       "name": "@user-office-software/duo-validation",
-      "version": "5.1.7",
+      "version": "5.1.8",
       "license": "ISC",
       "dependencies": {
         "luxon": "^2.5.0",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/duo-validation",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "Duo frontend and backend validation in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/duo-validation",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "description": "Duo frontend and backend validation in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/validation/src/Questionary/instrumentPicker.ts
+++ b/packages/validation/src/Questionary/instrumentPicker.ts
@@ -34,10 +34,11 @@ export const instrumentPickerValidationSchema = (field: any) => {
             timeRequested: Yup.string()
               .required('Request time field is required')
               .test('is-number?', 'Requested time is not valid', (value) => {
+                const timeValue = Number(value);
                 if (
-                  Number(value) <= 0 ||
-                  isNaN(Number(value)) ||
-                  !Number.isInteger(Number(value))
+                  isNaN(timeValue) ||
+                  timeValue <= 0 ||
+                  !Number.isInteger(timeValue)
                 )
                   return false;
                 else return true;
@@ -64,10 +65,11 @@ export const instrumentPickerValidationSchema = (field: any) => {
           timeRequested: Yup.string()
             .required('Request time field is required')
             .test('is-number?', 'Requested time is not valid', (value) => {
+              const timeValue = Number(value);
               if (
-                Number(value) <= 0 ||
-                isNaN(Number(value)) ||
-                !Number.isInteger(Number(value))
+                isNaN(timeValue) ||
+                timeValue <= 0 ||
+                !Number.isInteger(timeValue)
               )
                 return false;
               else return true;

--- a/packages/validation/src/Questionary/instrumentPicker.ts
+++ b/packages/validation/src/Questionary/instrumentPicker.ts
@@ -34,7 +34,12 @@ export const instrumentPickerValidationSchema = (field: any) => {
             timeRequested: Yup.string()
               .required('Request time field is required')
               .test('is-number?', 'Requested time is not valid', (value) => {
-                if (Number(value) <= 0 || isNaN(Number(value))) return false;
+                if (
+                  Number(value) <= 0 ||
+                  isNaN(Number(value)) ||
+                  !Number.isInteger(Number(value))
+                )
+                  return false;
                 else return true;
               }),
           })
@@ -59,7 +64,12 @@ export const instrumentPickerValidationSchema = (field: any) => {
           timeRequested: Yup.string()
             .required('Request time field is required')
             .test('is-number?', 'Requested time is not valid', (value) => {
-              if (Number(value) <= 0 || isNaN(Number(value))) return false;
+              if (
+                Number(value) <= 0 ||
+                isNaN(Number(value)) ||
+                !Number.isInteger(Number(value))
+              )
+                return false;
               else return true;
             }),
         })


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
This PR restricts the requested time for an instrument to be an integer
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
closes https://github.com/UserOfficeProject/issue-tracker/issues/1134
<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
This has been tested by temporarily moving the schemas inside the user-office-core and importing from there.
- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
