### PR TITLE
feat: Refactor RabbitMQMessageBroker handle multiple consumer registration calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18605,7 +18605,7 @@
     },
     "packages/message-broker": {
       "name": "@user-office-software/duo-message-broker",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "ISC",
       "dependencies": {
         "@types/amqplib": "^0.10.1",

--- a/packages/message-broker/package.json
+++ b/packages/message-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/duo-message-broker",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "",
   "author": "SWAP",
   "license": "ISC",

--- a/packages/message-broker/src/consumer.ts
+++ b/packages/message-broker/src/consumer.ts
@@ -1,0 +1,24 @@
+import { ConsumerCallback } from './index';
+
+// This class is used to store the callback function and whether it is registered or not.
+export class Consumer {
+  callback: ConsumerCallback;
+  registered: boolean;
+
+  constructor(callback: ConsumerCallback) {
+    this.callback = callback;
+    this.registered = false;
+  }
+
+  register() {
+    this.registered = true;
+  }
+
+  unregister() {
+    this.registered = false;
+  }
+
+  isRegistered() {
+    return this.registered;
+  }
+}


### PR DESCRIPTION
This resolves the issue where consumers are registered on the queue multiple times if the listenOn function is called more than once.