### PR TITLE
fix: text input validation fix for isRequired and min length conflict

### DIFF
--- a/packages/validation/jestconfig.json
+++ b/packages/validation/jestconfig.json
@@ -1,0 +1,7 @@
+{
+  "transform": {
+    "^.+\\.(t|j)sx?$": "ts-jest"
+  },
+  "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
+}

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@user-office-software/duo-validation",
-  "version": "5.1.13",
+  "version": "5.1.14",
   "description": "Duo frontend and backend validation in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -8,7 +8,8 @@
   "license": "ISC",
   "scripts": {
     "clean": "rm -rf ./lib",
-    "build": "npm run clean && tsc -p ./tsconfig.build.json"
+    "build": "npm run clean && tsc -p ./tsconfig.build.json",
+    "test": "jest --config jestconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/validation/src/Questionary/textInput.spec.ts
+++ b/packages/validation/src/Questionary/textInput.spec.ts
@@ -1,0 +1,133 @@
+import { textInputQuestionValidationSchema } from './textInput';
+describe('TextInput config required true', () => {
+
+    let schema: ReturnType<typeof textInputQuestionValidationSchema>;
+    beforeAll(() => {
+        schema = textInputQuestionValidationSchema({
+            config: {
+                required: true,
+                min: 5,
+                max: 10
+            }
+        });
+    });
+    test('should be required', async () => {
+        await expect(schema.isValid('')).resolves.toBe(false);
+    });
+    test('should be valid when value is 5 characters', async () => {
+        await expect(schema.isValid('12345')).resolves.toBe(true);
+    }
+    );
+    test('should be valid when value is 10 characters', async () => {
+        await expect(schema.isValid('1234567890')).resolves.toBe(true);
+    }
+    );
+    test('should be invalid when value is 4 characters', async () => {
+        await expect(schema.isValid('1234')).resolves.toBe(false);
+    }
+    );
+    test('should be invalid when value is 11 characters', async () => {
+        await expect(schema.isValid('12345678901')).resolves.toBe(false);
+    });
+    
+    test('should be invalid when value is null', async () => {
+        await expect(schema.isValid(null)).resolves.toBe(false);
+    });
+    
+    test('should be invalid when value is undefined', async () => {
+        await expect(schema.isValid(undefined)).resolves.toBe(false);
+    });
+})
+
+describe('TextInput config required false', () => {
+    let schema: ReturnType<typeof textInputQuestionValidationSchema>;
+    beforeAll(() => {
+        schema = textInputQuestionValidationSchema({
+            config: {
+                required: false,
+                min: 5,
+                max: 10
+            }
+        });
+    });
+    
+    test('should be valid when value is empty string', async () => {
+        await expect(schema.isValid('')).resolves.toBe(true);
+    });
+    
+    test('should be valid when value is null', async () => {
+        await expect(schema.isValid(null)).resolves.toBe(true);
+    });
+    
+    test('should be valid when value meets min/max constraints', async () => {
+        await expect(schema.isValid('12345')).resolves.toBe(true);
+        await expect(schema.isValid('1234567890')).resolves.toBe(true);
+    });
+    
+    test('should be invalid when value is below min length', async () => {
+        await expect(schema.isValid('1234')).resolves.toBe(false);
+    });
+    
+    test('should be invalid when value exceeds max length', async () => {
+        await expect(schema.isValid('12345678901')).resolves.toBe(false);
+    });
+});
+
+describe('TextInput with only min constraint', () => {
+    let schema: ReturnType<typeof textInputQuestionValidationSchema>;
+    beforeAll(() => {
+        schema = textInputQuestionValidationSchema({
+            config: {
+                required: true,
+                min: 3
+            }
+        });
+    });
+    
+    test('should be valid when value is at or above min length', async () => {
+        await expect(schema.isValid('123')).resolves.toBe(true);
+        await expect(schema.isValid('1234567890')).resolves.toBe(true);
+    });
+    
+    test('should be invalid when value is below min length', async () => {
+        await expect(schema.isValid('12')).resolves.toBe(false);
+    });
+});
+
+describe('TextInput with only max constraint', () => {
+    let schema: ReturnType<typeof textInputQuestionValidationSchema>;
+    beforeAll(() => {
+        schema = textInputQuestionValidationSchema({
+            config: {
+                required: true,
+                max: 8
+            }
+        });
+    });
+    
+    test('should be valid when value is at or below max length', async () => {
+        await expect(schema.isValid('')).resolves.toBe(false); // Still required
+        await expect(schema.isValid('12345678')).resolves.toBe(true);
+    });
+    
+    test('should be invalid when value exceeds max length', async () => {
+        await expect(schema.isValid('123456789')).resolves.toBe(false);
+    });
+});
+
+describe('TextInput with no constraints', () => {
+    let schema: ReturnType<typeof textInputQuestionValidationSchema>;
+    beforeAll(() => {
+        schema = textInputQuestionValidationSchema({
+            config: {
+                required: false
+            }
+        });
+    });
+    
+    test('should be valid for any string input', async () => {
+        await expect(schema.isValid('')).resolves.toBe(true);
+        await expect(schema.isValid('short')).resolves.toBe(true);
+        await expect(schema.isValid('very long text with many characters')).resolves.toBe(true);
+    });
+});

--- a/packages/validation/src/Questionary/textInput.ts
+++ b/packages/validation/src/Questionary/textInput.ts
@@ -1,14 +1,22 @@
 import * as Yup from 'yup';
 
 export const textInputQuestionValidationSchema = (field: any) => {
-  let schema = Yup.string();
+  let schema = Yup.string().nullable();
   const config = field.config;
   config.required && (schema = schema.required('This is a required field'));
-  config.min &&
-    (schema = schema.min(
-      config.min,
-      `Value must be at least ${config.min} characters`
-    ));
+
+  if (config.min) {
+    schema = schema.test(
+      'min',
+      `Value must be at least ${config.min} characters`,
+      (value) => {
+        if (!value || value.length === 0) return true;
+
+        return value.length >= config.min;
+      }
+    );
+  }
+
   config.max &&
     (schema = schema.max(
       config.max,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

feat: fix bug with where if required is not selected but minimum set >0 then validation fails if field left empty.
Expected behaviour is if field left not required, but minimum set >0, then if the field is left empty it should OK.



## How Has This Been Tested

Covered all scenarios with tests

## Fixes
SWAP-4132

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.

