### PR TITLE
refactor: remove unused fields from user validation schemas

### DIFF
--- a/packages/validation/src/User/index.spec.ts
+++ b/packages/validation/src/User/index.spec.ts
@@ -1,0 +1,208 @@
+import * as Yup from 'yup';
+import * as UserValidation from './index';
+
+describe('User validation schemas', () => {
+    describe('deleteUserValidationSchema', () => {
+        it('should validate with correct data', async () => {
+            const validData = { id: 1 };
+            await expect(
+                UserValidation.deleteUserValidationSchema.validate(validData)
+            ).resolves.toEqual(validData);
+        });
+
+        it('should fail when id is missing', async () => {
+            const invalidData = {};
+            await expect(
+                UserValidation.deleteUserValidationSchema.validate(invalidData)
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('createUserByEmailInviteValidationSchema', () => {
+        const UserRole = { USER: 'user', ADMIN: 'admin' };
+        const schema = UserValidation.createUserByEmailInviteValidationSchema(UserRole);
+
+        it('should validate with correct data', async () => {
+            const validData = {
+                firstname: 'John',
+                lastname: 'Doe',
+                email: 'john.doe@example.com',
+                userRole: 'USER',
+            };
+            await expect(schema.validate(validData)).resolves.toEqual(validData);
+        });
+
+        it('should fail when required fields are missing', async () => {
+            const invalidData = { email: 'john.doe@example.com' };
+            await expect(schema.validate(invalidData)).rejects.toThrow();
+        });
+
+        it('should fail when email is invalid', async () => {
+            const invalidData = {
+                firstname: 'John',
+                lastname: 'Doe',
+                email: 'invalid-email',
+                userRole: 'user',
+            };
+            await expect(schema.validate(invalidData)).rejects.toThrow();
+        });
+
+        it('should fail when role is not in UserRole', async () => {
+            const invalidData = {
+                firstname: 'John',
+                lastname: 'Doe',
+                email: 'john.doe@example.com',
+                userRole: 'invalid-role',
+            };
+            await expect(schema.validate(invalidData)).rejects.toThrow();
+        });
+    });
+
+    describe('signInValidationSchema', () => {
+        it('should validate with correct credentials', async () => {
+            const validData = {
+                email: 'user@example.com',
+                password: 'Password123',
+            };
+            await expect(
+                UserValidation.signInValidationSchema.validate(validData)
+            ).resolves.toEqual(validData);
+        });
+
+        it('should fail when email is invalid', async () => {
+            const invalidData = {
+                email: 'not-an-email',
+                password: 'Password123',
+            };
+            await expect(
+                UserValidation.signInValidationSchema.validate(invalidData)
+            ).rejects.toThrow();
+        });
+
+        it('should fail when password is too short', async () => {
+            const invalidData = {
+                email: 'user@example.com',
+                password: 'short',
+            };
+            await expect(
+                UserValidation.signInValidationSchema.validate(invalidData)
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('updatePasswordValidationSchema', () => {
+        it('should validate with correct data', async () => {
+            const validData = {
+                id: 1,
+                password: 'Password123',
+            };
+            await expect(
+                UserValidation.updatePasswordValidationSchema.validate(validData)
+            ).resolves.toEqual(validData);
+        });
+
+        it('should fail when password does not meet requirements', async () => {
+            const invalidData = {
+                id: 1,
+                password: 'password', // no uppercase or numbers
+            };
+            await expect(
+                UserValidation.updatePasswordValidationSchema.validate(invalidData)
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('userPasswordFieldValidationSchema', () => {
+        it('should validate with matching passwords', async () => {
+            const validData = {
+                password: 'Password123',
+                confirmPassword: 'Password123',
+            };
+            await expect(
+                UserValidation.userPasswordFieldValidationSchema.validate(validData)
+            ).resolves.toEqual(validData);
+        });
+
+        it('should fail when passwords do not match', async () => {
+            const invalidData = {
+                password: 'Password123',
+                confirmPassword: 'DifferentPassword123',
+            };
+            await expect(
+                UserValidation.userPasswordFieldValidationSchema.validate(invalidData)
+            ).rejects.toThrow('Confirm password does not match password');
+        });
+    });
+
+    describe('createUserValidationSchema', () => {
+        it('should validate with correct user data', async () => {
+            const validData = {
+                firstname: 'John',
+                lastname: 'Doe',
+                gender: 'male',
+                user_title: 'Mr',
+                email: 'john.doe@example.com',
+                password: 'Password123',
+                confirmPassword: 'Password123',
+                birthdate: new Date(1990, 1, 1),
+                institutionId: 1,
+                department: 'Research',
+                position: 'Researcher',
+                telephone: '+1234567890',
+            };
+            await expect(
+                UserValidation.createUserValidationSchema.validate(validData)
+            ).resolves.toMatchObject(validData);
+        });
+
+        it('should fail when user is under 18', async () => {
+            const today = new Date();
+            const underageDate = new Date(
+                today.getFullYear() - 17,
+                today.getMonth(),
+                today.getDate()
+            );
+            
+            const invalidData = {
+                firstname: 'John',
+                lastname: 'Doe',
+                gender: 'male',
+                user_title: 'Mr',
+                email: 'john.doe@example.com',
+                password: 'Password123',
+                confirmPassword: 'Password123',
+                birthdate: underageDate,
+                institutionId: 1,
+                department: 'Research',
+                position: 'Researcher',
+                telephone: '+1234567890',
+            };
+            
+            await expect(
+                UserValidation.createUserValidationSchema.validate(invalidData)
+            ).rejects.toThrow('You must be at least 18 years old');
+        });
+
+        it('should validate with optional preferredname', async () => {
+            const validData = {
+                firstname: 'John',
+                lastname: 'Doe',
+                preferredname: 'Johnny',
+                gender: 'male',
+                user_title: 'Mr',
+                email: 'john.doe@example.com',
+                password: 'Password123',
+                confirmPassword: 'Password123',
+                birthdate: new Date(1990, 1, 1),
+                institutionId: 1,
+                department: 'Research',
+                position: 'Researcher',
+                telephone: '+1234567890',
+            };
+            
+            await expect(
+                UserValidation.createUserValidationSchema.validate(validData)
+            ).resolves.toMatchObject(validData);
+        });
+    });
+});

--- a/packages/validation/src/User/index.ts
+++ b/packages/validation/src/User/index.ts
@@ -26,11 +26,9 @@ const passwordValidationSchema = Yup.string()
 
 export const createUserValidationSchema = Yup.object().shape({
   firstname: Yup.string().required().min(2).max(50),
-  middlename: Yup.string().notRequired().max(50),
   preferredname: Yup.string().notRequired().max(50),
   lastname: Yup.string().required().min(2).max(50),
   gender: Yup.string().required(),
-  nationality: Yup.number().required(),
   user_title: Yup.string().required(),
   email: Yup.string().email().required(),
   password: passwordValidationSchema,
@@ -73,16 +71,13 @@ export const createUserValidationSchema = Yup.object().shape({
     .max(30)
     .matches(phoneRegExp, 'telephone number is not valid')
     .required(),
-  telephone_alt: Yup.string().max(50),
 });
 
 export const updateUserValidationSchema = Yup.object().shape({
   firstname: Yup.string().min(2).max(50).required(),
-  middlename: Yup.string().notRequired().max(50),
   preferredname: Yup.string().notRequired().max(50),
   lastname: Yup.string().min(2).max(50).required(),
   gender: Yup.string().required(),
-  nationality: Yup.number().required(),
   user_title: Yup.string().required(),
   email: Yup.string().email().required(),
   birthdate: Yup.date()
@@ -115,17 +110,14 @@ export const updateUserValidationSchema = Yup.object().shape({
     .max(30)
     .matches(phoneRegExp, 'telephone number is not valid')
     .required(),
-  telephone_alt: Yup.string().max(50),
 });
 
 export const updateUserValidationBackendSchema = Yup.object().shape({
   id: Yup.number().required(),
   firstname: Yup.string().min(2).max(50).notRequired(),
-  middlename: Yup.string().optional().max(50),
   preferredname: Yup.string().notRequired().max(50),
   lastname: Yup.string().min(2).max(50).notRequired(),
   gender: Yup.string().notRequired(),
-  nationality: Yup.number().notRequired(),
   user_title: Yup.string().notRequired(),
   email: Yup.string().email().notRequired(),
   birthdate: Yup.date()
@@ -153,7 +145,6 @@ export const updateUserValidationBackendSchema = Yup.object().shape({
     .max(30)
     .matches(phoneRegExp, 'telephone number is not valid')
     .notRequired(),
-  telephone_alt: Yup.string().max(50),
 });
 
 export const updateUserRolesValidationSchema = Yup.object().shape({


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Remove unused fields

## Motivation and Context

This is a complementary PR for  https://github.com/UserOfficeProject/user-office-core/pull/1059
Without this change the PR fails.

## How Has This Been Tested
Added tests to cover critical use cases

## Fixes

SWAP-4687

## Changes

Removed 
- middlename
- nationality
- telephone alt.

## Depends on


https://github.com/UserOfficeProject/user-office-core/pull/1059

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.

