### PR TITLE
feat: add dependabot config (same format as user office core)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'
+    # Limit PRs open from dependabot to avoid reaching job runners limt
+    open-pull-requests-limit: 2
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen because docker hub doesn't want slashes
+      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
+      separator: '-'
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This adds a 7 day cooldown to dependabot for all the the package managers.

<!--- Describe your changes in detail -->

## Motivation and Context

This allows a week for security screening on the version updates and only allows 2 dependabot prs per package manager so it doesn't become overwhelming

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

I am not able to test this as far as I know but I read the documentation and it said to do it this way

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://github.com/UserOfficeProject/issue-tracker/issues/1507

<!--- Does this fix a user story, if so add a reference here -->

## Changes

Changed dependabot yaml to add cooldown to all package managers in the repo.

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
